### PR TITLE
Allow user to override Aurora Files configs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,23 +7,24 @@ RUN apt-get update
 RUN apt-get upgrade -y
 
 RUN apt-get install -y \
-	wget \
-	zip \
-	unzip \
-	php7.4 \
-	php7.4-cli \
-	php7.4-common \
-	php7.4-curl \
-	php7.4-json \
-	php7.4-mbstring \
-	php7.4-mysql \
-	php7.4-xml \
-	apache2 \
-	libapache2-mod-php7.4 \
-	mariadb-common \
-	mariadb-server \
-	mariadb-client
-	
+    wget \
+    zip \
+    unzip \
+    php7.4 \
+    php7.4-cli \
+    php7.4-common \
+    php7.4-curl \
+    php7.4-json \
+    php7.4-mbstring \
+    php7.4-mysql \
+    php7.4-xml \
+    apache2 \
+    libapache2-mod-php7.4 \
+    mariadb-common \
+    mariadb-server \
+    mariadb-client \
+    jq
+
 ENV LOG_STDOUT **Boolean**
 ENV LOG_STDERR **Boolean**
 ENV LOG_LEVEL warn

--- a/README.md
+++ b/README.md
@@ -32,10 +32,15 @@ and access the installation at http://localhost:800/
 Accessing admin interface
 ------------------------------
 
-To configure Aurora Files installation, log into admin interface using main installation URL.
+To configure Aurora Files installation, log into admin interface using main installation URL and `/adminpanel` path.
 
 Default credentials are **superadmin** login and empty password.
 
+Overriding configuration
+------------------------------
+
+To override Aurora Files configuration, put config files with overrides into `/opt/afterlogic/data/settings` or 
+`/opt/afterlogic/data/settings/modules`. The file names must be the same as the ones you want to override.
 
 Licensing Terms & Conditions
 ----------------------------


### PR DESCRIPTION
This PR fixes https://github.com/afterlogic/docker-aurora-files/issues/8.

To override configs user can put config files with overrides into the `/opt/afterlogic/data/settings` folder inside the container and at each container start these overrides will be applied.  

The `/data/settings` folder path is the same as in the Aurora files to make the solution be able to scale if there will be need to override anything else.  The `settings` folder structure is also the same as in the Aurora Files to to make it easier for the user to navigate.

**Usage example**

Folder structure:
```
.
├── Dockerfile
└── settings
    ├── config.json
    └── modules
        └── AdminAuth.config.json
```

**Dockerfile**

```dockerfile
FROM this_aurorafiles_image:latest

COPY settings/ /opt/afterlogic/data/settings/
```

**config.json**

```json
{
  "EnableMultiTenant": [
    false,
    "bool"
  ]
}
```

**AdminAuth.config.json**

```json
{
  "AllowLoginFromCoreModule": [
    true,
    "bool"
  ]
}
```